### PR TITLE
validators for session model and serializer

### DIFF
--- a/fit_tracker/apps/api/models.py
+++ b/fit_tracker/apps/api/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.db.models import Q
 from django.db.models import Count, Sum, Avg, Max
 from django.utils import timezone
+from django.core.exceptions import ValidationError
 
 
 class Summary(models.Model):
@@ -50,6 +51,12 @@ class Session(models.Model):
     distance = models.DecimalField(max_digits = 4, decimal_places = 1)
     length_time = models.DurationField()
     session_date = models.DateTimeField(default = timezone.now)
+
+    def clean(self):
+        super().clean()
+        for activity in ['running', 'cycling', 'hiking', 'swimming', 'walking']:
+            if self.session_type == activity and self.summary.summary_type != activity:
+                raise ValidationError(f"Summary type must be '{activity}' for sessions with type '{activity}'")
 
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)

--- a/fit_tracker/apps/api/serializers.py
+++ b/fit_tracker/apps/api/serializers.py
@@ -8,6 +8,16 @@ class SessionSerializer(serializers.ModelSerializer):
         model = Session
         fields = ['id', 'user', 'summary', 'session_type', 'intensity', 'distance', 'length_time', 'session_date']
 
+    def validate(self, data):
+        session_type_value = data.get('session_type')
+        summary = data.get('summary')
+
+        for activity in ['running' , 'cycling' , 'hiking' , 'swimming' , 'walking']:
+            if session_type_value == activity and summary.summary_type != activity:
+                raise serializers.ValidationError(f"Summary type must be {activity} for sessions with type {activity}")
+
+        return data
+
 
 class SummarySerializer(serializers.ModelSerializer):
     class Meta:

--- a/fit_tracker/tests/api/test_views.py
+++ b/fit_tracker/tests/api/test_views.py
@@ -2,9 +2,20 @@ from django.contrib.auth import get_user_model
 import pytest
 from apps.api.models import Session
 from django.test import Client
+from rest_framework.reverse import reverse
+from rest_framework import status
 
 
 User = get_user_model()
+
+
+@pytest.fixture
+def create_session_instance():
+    def _create_instance(**kwargs):
+        instance = Session.objects.create(**kwargs)
+        return instance
+
+    return _create_instance
 
 
 @pytest.fixture
@@ -14,10 +25,14 @@ def client():
 
 @pytest.fixture
 def authenticated_user(client):
-    # Create and authenticate a user
     user = User.objects.create_user(username='test_user', password='password')
     client.login(username='test_user', password='password')
     return user
+
+
+@pytest.fixture
+def not_authenticated_user(client):
+    return User.objects.create_user(username='test_nauser', password='napassword')
 
 
 @pytest.mark.django_db
@@ -29,19 +44,101 @@ def test_add_session(client, authenticated_user):
         "/my-activities/running/",
         {
             "user": authenticated_user.id,
+            "summary": 1,
             "session_type": "running",
-            "distance": "100.0",
             "intensity": "hard",
+            "distance": "100.0",
             "length_time": "00:01:00" ,
-            "start_date": "2023-05-15T11:15:34Z" ,
+            "session_date": "2023-05-15T11:15:34Z" ,
         },
         content_type="application/json"
     )
     assert resp.status_code == 201
-    assert resp.data["start_date"] == "2023-05-15T11:15:34Z"
+    assert resp.data["session_date"] == "2023-05-15T11:15:34Z"
 
     session = Session.objects.all()
     assert len(session) == 1
 
 
-# for now just the happy path
+@pytest.mark.django_db
+def test_add_session_not_authenticated_user(client, not_authenticated_user):
+    session = Session.objects.all()
+    assert len(session) == 0
+
+    resp = client.post(
+        "/my-activities/running/",
+        {
+            "user": not_authenticated_user.id,
+            "summary": 4,
+            "session_type": "running",
+            "intensity": "hard",
+            "distance": "100.0",
+            "length_time": "00:01:00" ,
+            "session_date": "2023-05-15T11:15:34Z" ,
+        },
+        content_type="application/json"
+    )
+    assert resp.status_code == 403
+
+    session = Session.objects.all()
+    assert len(session) == 0
+
+
+@pytest.mark.django_db
+def test_add_session_replaced_user(client, authenticated_user, not_authenticated_user):
+    session = Session.objects.all()
+    assert len(session) == 0
+
+    resp = client.post(
+        "/my-activities/running/",
+        {
+            "user": not_authenticated_user.id,
+            "summary": 7,
+            "session_type": "running",
+            "intensity": "hard",
+            "distance": "100.0",
+            "length_time": "00:01:00" ,
+            "session_date": "2023-05-15T11:15:34Z" ,
+        },
+        content_type="application/json"
+    )
+    assert resp.status_code == 400
+
+    session = Session.objects.all()
+    assert len(session) == 0
+
+
+# @pytest.mark.django_db
+# def test_delete_session(client, authenticated_user):
+#     session = Session.objects.all()
+#     assert len(session) == 0
+#
+#     resp = client.post(
+#         "/my-activities/running/",
+#         {
+#             "user": authenticated_user.id,
+#             "session_type": "running",
+#             "distance": "100.0",
+#             "intensity": "hard",
+#             "length_time": "00:01:00" ,
+#             "start_date": "2023-05-15T11:15:34Z" ,
+#         },
+#         content_type="application/json"
+#     )
+#     assert resp.status_code == 201
+#     assert resp.data["start_date"] == "2023-05-15T11:15:34Z"
+#
+#     session = Session.objects.all()
+#     assert len(session) == 1
+
+
+# @pytest.mark.django_db
+# def test_delete_instance(api_client, create_session_instance):
+#     instance = create_session_instance(user=99, session_type="running", distance=50, intensity='hard',
+#                                        length_time="00:01:00", start_date="2023-05-15T11:15:34Z")
+#
+#     url = reverse('your-model-detail', kwargs={'pk': instance.pk})  # Replace 'your-model-detail' with your actual URL name
+#     response = api_client.delete(url)
+#
+#     assert response.status_code == status.HTTP_204_NO_CONTENT
+#     assert not YourModel.objects.filter(pk=instance.pk).exists()


### PR DESCRIPTION
added validators to model and serializer so a user can only create a session instance related to summary instance with the same type, for example 'running'